### PR TITLE
update set_api_key security

### DIFF
--- a/R/set_api_key.R
+++ b/R/set_api_key.R
@@ -26,7 +26,7 @@ set_api_key <- function(path = stop("Please specify a path.")) {
   env_file <- readLines(path, encoding = "UTF-8")
   
   # setup key variable
-  key <- paste0("NEWS_API_KEY=", askpass::askpass("Please enter api key"))
+  key <- paste0("NEWS_API_KEY=", askpass::askpass("Please enter your api key"))
   
   # add api key
   env_file <- c(env_file, key)

--- a/R/set_api_key.R
+++ b/R/set_api_key.R
@@ -2,16 +2,13 @@
 #'
 #'@description Function to set you API Key to the R environment when starting using \code{newsanchor} package. Attention: You should only execute this functions once.
 #'
-#'@param api_key character. The personal API key To request an API key see: \url{https://newsapi.org/register}
 #'@param path character. Path where the environment is stored. Default is the normalized path.
 #'
 #'@return None.
 #'
 #'@examples
 #'\dontrun{
-#'# this is not an actual API key
-#'api_key <- "5t5yno5qqkufxis5q2vzx26vxq2hqej9"
-#'set_api_key(api_key, tempdir())
+#'set_api_key(tempdir()) # you will be prompted to enter your API key.
 #'}
 #'@author Jan Dix <\email{jan.d@@correlaid.org}>
 #'

--- a/R/set_api_key.R
+++ b/R/set_api_key.R
@@ -17,8 +17,7 @@
 #'
 #'@export
 
-set_api_key <- function(api_key,
-                        path = stop("Please specify a path.")) {
+set_api_key <- function(path = stop("Please specify a path.")) {
   
   # check if an environment file exists
   if (!file.exists(path)) file.create(path)
@@ -27,7 +26,7 @@ set_api_key <- function(api_key,
   env_file <- readLines(path, encoding = "UTF-8")
   
   # setup key variable
-  key <- paste0("NEWS_API_KEY=", api_key)
+  key <- paste0("NEWS_API_KEY=", askpass::askpass("Please enter api key"))
   
   # add api key
   env_file <- c(env_file, key)

--- a/man/set_api_key.Rd
+++ b/man/set_api_key.Rd
@@ -4,11 +4,9 @@
 \alias{set_api_key}
 \title{Add API key to the .Renviron}
 \usage{
-set_api_key(api_key, path = stop("Please specify a path."))
+set_api_key(path = stop("Please specify a path."))
 }
 \arguments{
-\item{api_key}{character. The personal API key To request an API key see: \url{https://newsapi.org/register}}
-
 \item{path}{character. Path where the environment is stored. Default is the normalized path.}
 }
 \value{
@@ -19,9 +17,7 @@ Function to set you API Key to the R environment when starting using \code{newsa
 }
 \examples{
 \dontrun{
-# this is not an actual API key
-api_key <- "5t5yno5qqkufxis5q2vzx26vxq2hqej9"
-set_api_key(api_key, tempdir())
+set_api_key(tempdir()) # you will be prompted to enter your API key.
 }
 }
 \author{


### PR DESCRIPTION
I have removed the argument `api_key` from the `set_api_key()` function, and inserted `askpass::askpass("Please enter your api key")` further down in the function in its place. This will prevent the users api key from being stored in their .Rhistory file (which could get published online).

Hadley Wickham covered this topic in his vignette [Managing Secrets](https://cran.r-project.org/web/packages/httr/vignettes/secrets.html) where he states: "You should never type your password into the R console: this will typically be stored in the .Rhistory file, and it’s easy to accidentally share without realising it."

I am writing a similar function in a package I am writing and reached out over Twitter and he [recommended](https://twitter.com/MikeJohnPage/status/1120671451625836545) using `askpass::askpass()`.